### PR TITLE
修复aws RecordID 指标重复报错问题

### DIFF
--- a/pkg/export/export_gauge.go
+++ b/pkg/export/export_gauge.go
@@ -171,10 +171,16 @@ func (c *Metrics) Collect(ch chan<- prometheus.Metric) {
 				logger.Error(fmt.Sprintf("[ %s ] json.Unmarshal error: %v", recordCertInfoCacheKey, err))
 				continue
 			}
+			seenIDs := make(map[string]bool)
 			for _, v := range recordCerts {
 				if v.RecordID == "" {
 					continue
 				}
+				if seenIDs[v.RecordID] {
+                    logger.Error(fmt.Sprintf("【Duplicate Found】Cloud: %s, Domain: %s, RecordID: %s is duplicated!", v.CloudName, v.FullRecord, v.RecordID))
+					continue
+                }
+                seenIDs[v.RecordID] = true
 				ch <- prometheus.MustNewConstMetric(c.metrics[public.RecordCertInfo], prometheus.GaugeValue, float64(v.DaysUntilExpiry), v.CloudProvider, v.CloudName, v.DomainName, v.RecordID, v.FullRecord, v.SubjectCommonName, v.SubjectOrganization, v.SubjectOrganizationalUnit, v.IssuerCommonName, v.IssuerOrganization, v.IssuerOrganizationalUnit, v.CreatedDate, v.ExpiryDate, fmt.Sprintf("%t", v.CertMatched), v.ErrorMsg)
 			}
 		}

--- a/pkg/export/export_gauge.go
+++ b/pkg/export/export_gauge.go
@@ -177,10 +177,10 @@ func (c *Metrics) Collect(ch chan<- prometheus.Metric) {
 					continue
 				}
 				if seenIDs[v.RecordID] {
-                    logger.Error(fmt.Sprintf("【Duplicate Found】Cloud: %s, Domain: %s, RecordID: %s is duplicated!", v.CloudName, v.FullRecord, v.RecordID))
+					logger.Error(fmt.Sprintf("【Duplicate Found】Cloud: %s, Domain: %s, RecordID: %s is duplicated!", v.CloudName, v.FullRecord, v.RecordID))
 					continue
-                }
-                seenIDs[v.RecordID] = true
+				}
+				seenIDs[v.RecordID] = true
 				ch <- prometheus.MustNewConstMetric(c.metrics[public.RecordCertInfo], prometheus.GaugeValue, float64(v.DaysUntilExpiry), v.CloudProvider, v.CloudName, v.DomainName, v.RecordID, v.FullRecord, v.SubjectCommonName, v.SubjectOrganization, v.SubjectOrganizationalUnit, v.IssuerCommonName, v.IssuerOrganization, v.IssuerOrganizationalUnit, v.CreatedDate, v.ExpiryDate, fmt.Sprintf("%t", v.CertMatched), v.ErrorMsg)
 			}
 		}

--- a/pkg/provider/amazon.go
+++ b/pkg/provider/amazon.go
@@ -141,12 +141,12 @@ func (a *AmazonDNS) ListRecords() ([]Record, error) {
 				CloudName:     a.account.CloudName,
 				DomainName:    domain,
 				// RecordID:      public.GetID(),
-				RecordType:    string(record.Type),
-				RecordWeight:  fmt.Sprintf("%d", record.Weight),
-				RecordStatus:  oneStatus("enable"),
-				RecordRemark:  tea.StringValue(nil),
-				UpdateTime:    carbon.CreateFromTimestampMilli(tea.Int64Value(nil)).ToDateTimeString(),
-				FullRecord:    strings.TrimSuffix(tea.StringValue(record.Name), "."),
+				RecordType:   string(record.Type),
+				RecordWeight: fmt.Sprintf("%d", record.Weight),
+				RecordStatus: oneStatus("enable"),
+				RecordRemark: tea.StringValue(nil),
+				UpdateTime:   carbon.CreateFromTimestampMilli(tea.Int64Value(nil)).ToDateTimeString(),
+				FullRecord:   strings.TrimSuffix(tea.StringValue(record.Name), "."),
 			}
 			// aws域名返回完整域名处理
 			recordName := strings.TrimSuffix(tea.StringValue(record.Name), ".")

--- a/pkg/provider/amazon.go
+++ b/pkg/provider/amazon.go
@@ -140,7 +140,7 @@ func (a *AmazonDNS) ListRecords() ([]Record, error) {
 				CloudProvider: a.account.CloudProvider,
 				CloudName:     a.account.CloudName,
 				DomainName:    domain,
-				RecordID:      public.GetID(),
+				// RecordID:      public.GetID(),
 				RecordType:    string(record.Type),
 				RecordWeight:  fmt.Sprintf("%d", record.Weight),
 				RecordStatus:  oneStatus("enable"),
@@ -162,6 +162,7 @@ func (a *AmazonDNS) ListRecords() ([]Record, error) {
 			}
 			if record.ResourceRecords != nil {
 				for _, record := range record.ResourceRecords {
+					recordInfo.RecordID = public.GetID()
 					recordInfo.RecordValue = tea.StringValue(record.Value)
 					dataObj = append(dataObj, recordInfo)
 				}


### PR DESCRIPTION
Fixes #36 

- 解决aws route 53一条解析有多个记录时，会使用重复的record_id，导致Prometheus采集报错
- 如果发生label 一致 Prometheus会丢弃指标，采集时增加防御逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 增强了导出与采集流程中同一批次内的重复记录检测，重复条目将被记录并跳过以防止重复上报
  * 优化了记录 ID 的分配时机，由聚合级别调整为逐条资源级别分配，提升记录一致性与准确性

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->